### PR TITLE
Otimizando consumo de cpu para imagens iguais

### DIFF
--- a/main.go
+++ b/main.go
@@ -36,7 +36,7 @@ func main() {
 
 	go clearCache()
 
-	//gin.SetMode(gin.ReleaseMode)
+	gin.SetMode(gin.ReleaseMode)
 	r := gin.Default()
 
 	r.GET("/", func(c *gin.Context) {
@@ -169,7 +169,7 @@ func imageToBytes(image image.Image) (*bytes.Buffer, error) {
 }
 
 func getPort() (string) {
-	port := "8081"
+	port := "8080"
 	if len(os.Args) > 1 {
 		port = os.Args[1]
 	}

--- a/main.go
+++ b/main.go
@@ -58,12 +58,12 @@ func main() {
 
 		background := c.DefaultQuery("bg", "666666")
 		fColor := c.DefaultQuery("c", "FFFFFF")
-		text := c.DefaultQuery("t", fmt.Sprintf("%d x %d", width, height))
-
 
 		if err != nil {
 			height = width
 		}
+
+		text := c.DefaultQuery("t", fmt.Sprintf("%d x %d", width, height))
 
 		if width > maxImageSize || height > maxImageSize {
 			html(c, http.StatusInternalServerError, renderError("A imagem deve ter no máximo 5000 x 5000"))
@@ -84,7 +84,7 @@ func main() {
 		}
 
 		if image, ok := cache[keyMap] ; ok{
-			c.Data(http.StatusOK, "image/png", image.image.Bytes())
+			sendImage(c,image.image)
 			cache[keyMap].lifeTime = time.Now().Add(cacheTimeInSeconds * time.Second).Unix()
 			return
 		}
@@ -97,14 +97,18 @@ func main() {
 			html(c, http.StatusInternalServerError, renderError(err.Error()))
 			return
 		}
-
-		c.Data(http.StatusOK, "image/png", image.Bytes())
+		sendImage(c,image)
 	})
 
 	r.Run(getPort())
 
+}
 
-
+func sendImage(c *gin.Context, image *bytes.Buffer){
+	c.Header("Pragma","public")
+	c.Header("Cache-Control","max-age=86400")
+	c.Header("Expires",time.Now().AddDate(60, 0, 0).Format(http.TimeFormat))
+	c.Data(http.StatusOK, "image/png", image.Bytes())
 }
 
 func clearCache(){

--- a/main.go
+++ b/main.go
@@ -25,8 +25,8 @@ type cacheImage struct{
 const (
 	maxImageSize = 5000
 	minImageSize = 50
-	cacheTimeInSeconds = 10
-	cacheRemoveRoutineTimeInSeconds = 1
+	cacheTimeInSeconds = 100
+	cacheRemoveRoutineTimeInSeconds = 5
 )
 
 var cache = make(map[string]*cacheImage)


### PR DESCRIPTION
No caso de a mesma imagem estar sendo gerada ao mesmo tempo, é colocado uma flag indicando que a imagem está sendo processada e as demais imagens devem aguardar essa geração, depois que a imagem for gerada as demais requisições obtém a imagem do cache evitando processamento desnecessário